### PR TITLE
OTP Memory Read: bug fix

### DIFF
--- a/dev/dw1000/dw1000.c
+++ b/dev/dw1000/dw1000.c
@@ -1730,7 +1730,7 @@ dw_read_otp_32(uint16_t otp_addr)
 {
   static const uint8_t cmd[] = {
     /* Enable manual read */
-    DW_OTPRDEN_MASK || DW_OTPREAD_MASK,
+    DW_OTPRDEN_MASK | DW_OTPREAD_MASK,
     /* Do the actual read */
     DW_OTPREAD_MASK,
     /* Reset otp_ctrl */


### PR DESCRIPTION
The function to read the OTP memory was using a logical operator || instead of the bitwise OR operator |, producing wrong OTP memory readings.